### PR TITLE
Example for malfunctioning remoteUser

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,2 +1,17 @@
 FROM ubuntu:16.04
 ENV MYSQL_DATABASE DOCKERDB
+
+ARG USERNAME=testuser
+ARG USER_UID=1000
+ARG USER_GID=1000
+
+WORKDIR $HOME
+
+RUN groupadd --gid ${USER_GID} ${USERNAME} && \
+    useradd --uid ${USER_UID} --gid ${USER_GID} -m ${USERNAME} -s /bin/bash && \
+    apt-get update && \
+    apt-get install -y sudo && \
+    echo ${USERNAME} ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME} && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,8 +4,8 @@
 	"name": "idea-demo",
 //	Or use a Dockerfile here, more info: https://containers.dev/guide/dockerfile
 	"build": {
-			"dockerfile": "Dockerfile"
-		},
+		"dockerfile": "Dockerfile"
+	},
 	"remoteUser": "testuser"
 }
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,8 @@
 //	name of the dev container
 	"name": "idea-demo",
 //	Or use a Dockerfile here, more info: https://containers.dev/guide/dockerfile
-	"image":  "openjdk:11"
+	"image":  "openjdk:11",
 
+	"remoteUser": "testuser"
 }
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,11 @@
 	"build": {
 		"dockerfile": "Dockerfile"
 	},
-	"remoteUser": "testuser"
+
+	"remoteUser": "testuser",
+	"runArgs": [
+    "--gpus", "all",
+	"--env-file", ".devcontainer/test.env"
+  ]
 }
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,8 +3,9 @@
 //	name of the dev container
 	"name": "idea-demo",
 //	Or use a Dockerfile here, more info: https://containers.dev/guide/dockerfile
-	"image":  "openjdk:11",
-
+	"build": {
+			"dockerfile": "Dockerfile"
+		},
 	"remoteUser": "testuser"
 }
 


### PR DESCRIPTION
Code to replicate the malfunctioning  devcontainer option `remoteUser`.

### Simply follow these steps to reproduce:

1. Clone this repo
2. Build the devcontainer
![image](https://github.com/IdeaUJetBrains/idea-demo-devcontainers/assets/126877803/cfcafb36-a01f-4305-9265-be82c8e8a68a)
3. Connect to it

### Result
Terminal launches as root user:
```bash
root@b04427e63507:/IdeaProjects/idea-demo-devcontainers# 
```

Whereas it should be `testuser`.